### PR TITLE
Antoine sad paths

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -31,15 +31,17 @@ class Merchants::ItemsController < ApplicationController
   end
 
   def update
+    item = Item.find(params[:item_id])
     if params[:status].present?
-      item = Item.find(params[:item_id])
       item.update(status: params[:status].to_i)
       redirect_to merchant_items_path(params[:merchant_id])
-    else
-      item = Item.find(params[:item_id])
+    elsif params[:name].present? && params[:description].present? && params[:unit_price].present?
       item.update(item_params)
       redirect_to merchant_item_path(params[:merchant_id], params[:item_id])
       flash[:success] = "Item successfully updated!"
+    elsif !params[:name].present? || !params[:description].present? || !params[:unit_price].present? 
+      redirect_to edit_merchant_item_path(params[:merchant_id], params[:item_id])
+      flash[:error] = "Item not updated: Required information missing."
     end 
   end
 

--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -19,8 +19,15 @@ class Merchants::ItemsController < ApplicationController
 
   def create
     merchant = Merchant.find(params[:merchant_id])
-    item = merchant.items.create(item_params)
-    redirect_to merchant_items_path(merchant)
+    item = merchant.items.new(item_params)
+    item.save
+    if item.save
+      redirect_to merchant_items_path(merchant)
+      flash[:success] = "Item successfully created!"
+    elsif !item.save
+      redirect_to new_merchant_item_path(merchant)
+      flash[:error] = "Item not created: Required information missing."
+    end
   end
 
   def update

--- a/app/views/merchants/items/show.html.erb
+++ b/app/views/merchants/items/show.html.erb
@@ -1,12 +1,5 @@
 <h1><center><%= @item.name %></center></h1>
 
-<% if flash[:success].present? %>
-  <div class="alert alert-success">
-    <%= flash[:success] %>
-  </div>
-<% end %>
-
-<!--<p><strong>Name:</strong> <%= @item.name %></p>-->
 <p><strong>description:</strong> <%= @item.description %></p>
 <p><strong>Price:</strong> <%= @item.formatted_unit_price %></p>
 

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -30,5 +30,31 @@ RSpec.describe 'merchant item edit page' do
       expect(page).to have_content("Not Shiny")
       expect(page).to have_content("$50.00")
     end
+
+    it "US8 shows a flash message if the item is not updated" do
+      visit edit_merchant_item_path(@merchant_1, @item_1)
+
+      expect(page).to have_content("Edit #{@item_1.name}")
+      expect(page).to have_field(:name, with: @item_1.name)
+      expect(page).to have_field(:description, with: @item_1.description)
+      expect(page).to have_field(:unit_price, with: @item_1.unit_price)
+      expect(page).to have_button("Update Item")
+
+      fill_in(:name, with: "")
+      fill_in(:description, with: "Not Shiny")
+      fill_in(:unit_price, with: 5000)
+
+      click_button("Update Item")
+
+      expect(current_path).to eq(edit_merchant_item_path(@merchant_1, @item_1))
+      expect(page).to have_content("Item not updated: Required information missing.")
+
+      fill_in(:name, with: "Shiny")
+      fill_in(:description, with: "")
+      fill_in(:unit_price, with: 5000)
+
+      expect(current_path).to eq(edit_merchant_item_path(@merchant_1, @item_1)) 
+      expect(page).to have_content("Item not updated: Required information missing.")
+    end
   end
 end

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -30,5 +30,30 @@ RSpec.describe "Create new item form" do
       expect(page).to have_content("It's a thing")
       expect(page).to have_content("$10.00")
     end
+
+    it "US11 shows a flash message if the item is not created" do
+      visit new_merchant_item_path(@merchant_1)
+
+      expect(page).to have_field(:name)
+      expect(page).to have_field(:description)
+      expect(page).to have_field(:unit_price)
+      expect(page).to have_button("Create New Item")
+
+      fill_in(:name, with: "")
+      fill_in(:description, with: "It's a thing")
+      fill_in(:unit_price, with: 1000)
+      click_button("Create New Item")
+
+      expect(current_path).to eq(new_merchant_item_path(@merchant_1))
+      expect(page).to have_content("Item not created: Required information missing.")
+
+      fill_in(:name, with: "Thing")
+      fill_in(:description, with: "")
+      fill_in(:unit_price, with: "")
+      click_button("Create New Item")
+
+      expect(current_path).to eq(new_merchant_item_path(@merchant_1))
+      expect(page).to have_content("Item not created: Required information missing.")
+    end
   end
 end


### PR DESCRIPTION
#### Updates Made -
- User Stories Updated:
- Database/Migrations: 
- Routes:
- Models:
- Controllers:
update merchants items controller with some conditionals in both the create and update methods to account for sad paths where a user doesn't fill out a field in the form. Made custom flash message. 
- Views:
- Testing:
  - Models:
  - Features: test for both flash message in features/merchant/items/new && edit for the sad paths. 
  
- Considerations(Extra notes, refactors, etc.):

We could set up something similar to adopt don't shop where rails gives you the built in messages? I kinda like the control of the custom ones personally, but could be a good exercise. 

