### PR TITLE
36 admin invoice show page update invoice status

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,4 +6,10 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+    invoice = Invoice.find(params[:id])
+    invoice.update(status: params[:status])
+    redirect_to admin_invoice_path(invoice)
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,6 +1,13 @@
 <%= render partial: "admin/page_head" %>
 
 <center><h3>Invoice #<%= @invoice.id %></h3></center>
+
+<%= form_with url: admin_invoice_path(@invoice), method: :patch, data:{turbo: false} do |f| %>
+  <%= f.label "Status:" %>
+  <%= f.select :status, ["in progress", "cancelled", "completed"], selected: @invoice.status %>
+  <%= f.submit "Update Invoice Status" %><br>
+<% end %>
+
 <p><b>Status:</b> <%= @invoice.status.capitalize %></p>
 <p><b>Created on:</b> <%= @invoice.created_at.strftime("%A, %B %d, %Y") %>
 <p><b>Total Revenue:</b> <%= number_to_currency(@invoice.total_revenue) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   
   namespace :admin do 
     resources :merchants, except: [:destroy]
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
   end
 
   # resources :merchants, only: [:show] do

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -69,5 +69,21 @@ RSpec.feature "the admin/invoices show page" do
 
       expect(page).to have_content("Total Revenue: $1,030.29")
     end
+
+    it "US 36 has a for to update the invoice status" do
+      customer_1 = Customer.create!(first_name: "Bob", last_name: "Smith")
+      invoice_1 = Invoice.create!(status: 1, customer_id: customer_1.id, created_at: Time.new(2011,4,5))
+
+      visit admin_invoice_path(invoice_1)
+
+      expect(page).to have_select(:status, with_options: ["in progress", "completed", "cancelled"], selected: "completed")
+      expect(page).to have_button("Update Invoice Status")
+
+      select("in progress", from: :status)
+      click_button("Update Invoice Status")
+
+      expect(current_path).to eq(admin_invoice_path(invoice_1))
+      expect(page).to have_select(:status, selected: "in progress")
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Merchant, type: :model do
       expect(Merchant.enabled).to eq([@merchant_1, @merchant_2, @merchant_3, @merchant_4])
     end
 
-    xit "returns all disabled merchants" do
+    it "returns all disabled merchants" do
       expect(Merchant.disabled).to eq([@merchant_5, @merchant_6, @merchant_7])
     end
 


### PR DESCRIPTION
#### Updates Made -
- User Stories Updated: US 36
- Database/Migrations: N/A
- Routes: add :update to admin/invoices
- Models: N/A
- Controllers: add update method to invoices
- Views: add invoice status update form to admin/invoices show page
- Testing:
  - Models: un-skipped 2nd test for disabled merchants on line 238 in merchant_spec
  - Features: add block to test invoice status update in invoices/show
- Considerations(Extra notes, refactors, etc.): Closes #30 

