### PR TITLE
fix: US18 to update item status, not invoice status

### DIFF
--- a/app/controllers/merchants/invoices_controller.rb
+++ b/app/controllers/merchants/invoices_controller.rb
@@ -10,9 +10,14 @@ class Merchants::InvoicesController < ApplicationController
   end
 
   def update
-    @merchant = Merchant.find(params[:merchant_id])
-    @invoice = Invoice.find(params[:invoice_id])
-    @invoice.update!(status: params[:status])
-    redirect_to merchant_invoice_path(@merchant, @invoice)
+  if params[:item_status].present?
+    merchant = Merchant.find(params[:merchant_id])
+    invoice = Invoice.find(params[:invoice_id])
+    item = Item.find(params[:item_id])
+    invoice_item = InvoiceItem.find_by(invoice_id: params[:invoice_id], item_id: params[:item_id])
+    invoice_item.update!(status: params[:item_status])
+    invoice_item.save
+  end 
+    redirect_to merchant_invoice_path(params[:merchant_id], params[:invoice_id])
   end
 end

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -3,11 +3,6 @@
 <p><strong>ID:</strong> <%= @invoice.id %></p>
 <p><strong>Status:</strong> <%= @invoice.status %></p>
 
-<%= form_with models: @invoice, url: merchant_invoice_status_path(@merchant, @invoice), method: :patch, data:{turbo: false} do |f| %>
-  <%= select_tag :status, options_for_select([['cancelled', 'cancelled'], ['in progress', 'in progress'], ['completed', 'completed']], @invoice.status) %>
-  <%= f.submit 'Update Invoice Status' %>
-<% end %>
-
 <p><strong>Created At:</strong> <%= @invoice.created_at.strftime('%A, %B %d, %Y') %></p>
 <p><strong>Customer Name:</strong> <%= "#{@invoice.customer.first_name} #{@invoice.customer.last_name}" %></p>
 
@@ -19,6 +14,7 @@
       <th>Quantity</th>
       <th>Price</th>
       <th>Status</th>
+      <th>Change Status</th>
     </tr>
   </thead>
   <tbody>
@@ -27,7 +23,11 @@
         <td><%= invoice_item.item.name %></td>
         <td><%= invoice_item.quantity %></td>
         <td><%= number_to_currency(invoice_item.unit_price / 100.0) %></td>
-        <td><%= invoice_item.status %></td>
+        <td><%= invoice_item.status %></td>  
+        <td><%= form_with url: merchant_invoice_item_path(@merchant, @invoice, invoice_item.item_id), method: :patch, data:{turbo: false} do |f| %>
+            <%= select_tag :item_status, options_for_select([['packaged', 'packaged'], ['pending', 'pending'], ['shipped', 'shipped']], invoice_item.status) %>
+            <%= f.submit 'Update Item Status' %>
+            <% end %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   get "/merchants/:merchant_id/items/:item_id/edit", to: "merchants/items#edit", as: :edit_merchant_item
   patch "/merchants/:merchant_id/items/:item_id", to: "merchants/items#update"
   get "/merchants/:merchant_id/invoices", to: "merchants/invoices#index"
-  patch "/merchants/:merchant_id/invoices/:invoice_id", to: "merchants/invoices#update", as: :merchant_invoice_status
+  patch "/merchants/:merchant_id/invoices/:invoice_id/:item_id", to: "merchants/invoices#update", as: :merchant_invoice_item
   get "/merchants/:merchant_id/invoices/:invoice_id", to: "merchants/invoices#show", as: :merchant_invoice
   get "/admin", to: "admin#index"
   

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -52,19 +52,19 @@ RSpec.feature "the merchant invoices show page" do
       merchant_1 = create(:merchant)
       item_1 = create(:item, merchant: merchant_1)
       customer_1 = create(:customer)
-      invoice_1 = create(:invoice, status: 0)
-      invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1)
+      invoice_1 = create(:invoice)
+      invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, status: 0)
 
       visit merchant_invoice_path(merchant_1, invoice_1)
 
-      expect(invoice_1.status).to eq("in progress")
-      expect(page).to have_select(:status, options: ['cancelled', 'in progress', 'completed'])
-      select('cancelled', from: :status)
-      click_button('Update Invoice')
-      invoice_1.reload
+      expect(invoice_item_1.status).to eq("packaged")
+      expect(page).to have_select(:item_status, options: ['packaged', 'pending', 'shipped'])
+      select('pending', from: :item_status)
+      click_button('Update Item Status')
+      invoice_item_1.reload
       
       expect(current_path).to eq(merchant_invoice_path(merchant_1, invoice_1))
-      expect(invoice_1.status).to eq('cancelled')
+      expect(invoice_item_1.status).to eq('pending')
     end
   end
 end


### PR DESCRIPTION
#### Updates Made -
- User Stories Updated: 18 
- Database/Migrations: 
- Routes: made new route for item_invoice update
- Models:
- Controllers: changed the update method in the merchant invoice controller to update the invoice item rather than the item status
- Views: moved status update form to go next to each item in the invoice
- Testing:
  - Models:
  - Features: updated feature test for this form. Test passes. 
  
- Considerations(Extra notes, refactors, etc.):

